### PR TITLE
fixed syntax on extension hasOne loop

### DIFF
--- a/code/VersionHistoryExtension.php
+++ b/code/VersionHistoryExtension.php
@@ -95,7 +95,7 @@ class VersionHistoryExtension extends DataExtension
                 'Type' => 'Field',
             );
         }
-        foreach ($this->owner->hasOne() as $has1) {
+        foreach ($this->owner->hasOne() as $has1 => $fieldType) {
             $fieldNames[$has1] = array(
                 'FieldName' => $has1.'ID',
                 'Name' => $has1,


### PR DESCRIPTION
the loop was using the 'fieldtype' rather than the 'fieldname' causing some has one declarations to fail.

to replicate declare:

public static $has_one = array(
        'HasoneFirst' => 'FooDataObject',
        'HasoneSecond' => 'FooDataObject',
    );

and the CMS should fail with the message:

[User Error] Uncaught Exception: Object->__call(): the method 'FooDataObject' does not exist on 'Versioned_Version', or the method is not public.