### PR TITLE
Add the ability to hide some fields from the history tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ MyClass:
 
 This module currently doesn't distinguish between staged and published versions, nor does it support rolling back to a previous version, because I'm using it simply to track changes. If you want to expand the functionality though, feel free to open a pull request!
 
+### Hide some fields from the history tab
+
+If you want to hide some fields from the history tab, you can set the `version_history_hidden_fields` configuration attribute on your DataObject. The following YML configuration applies the `VersionHistoryExtenion` to the `Member` DataObject, but hides sensitive information like the `Salt` and `Password` fields.
+
+```yml
+Member:
+  extensions:
+    - Versioned("Stage")
+    - VersionHistoryExtension
+  version_history_hidden_fields:
+    - Password
+    - PasswordEncryption
+    - Salt
+```
+
 ## Maintainer contact
 
 [jonathonmenz.com](http://jonathonmenz.com)

--- a/code/VersionHistoryExtension.php
+++ b/code/VersionHistoryExtension.php
@@ -9,12 +9,14 @@ class VersionHistoryExtension extends DataExtension
             // URL for ajax request
             $urlBase = Director::absoluteURL('cms-version-history/compare/'.$this->owner->ClassName.'/'.$this->owner->ID.'/');
             $fields->findOrMakeTab('Root.VersionHistory', 'History');
-            $fields->addFieldToTab('Root.VersionHistory', LiteralField::create('VersionsHistoryMenu',
+            $fields->addFieldToTab('Root.VersionHistory', LiteralField::create(
+                'VersionsHistoryMenu',
                 "<div id=\"VersionHistoryMenu\" class=\"cms-content-tools\" data-url-base=\"$urlBase\">"
                 .$vFields->forTemplate()
                 .'</div>'
             ));
-            $fields->addFieldToTab('Root.VersionHistory', LiteralField::create('VersionComparisonSummary',
+            $fields->addFieldToTab('Root.VersionHistory', LiteralField::create(
+                'VersionComparisonSummary',
                 '<div id="VersionComparisonSummary">'
                 .$this->owner->VersionComparisonSummary()
                 .'</div>'
@@ -103,6 +105,19 @@ class VersionHistoryExtension extends DataExtension
             );
         }
         unset($fieldNames['Version']);
+
+        // Hide a some fields from the version history.
+        $hiddenFields = Config::inst()->get(
+            $this->owner->class,
+            'version_history_hidden_fields'
+        );
+        if (!empty($hiddenFields)) {
+            foreach ($hiddenFields as $hiddenField) {
+                if (isset($fieldNames[$hiddenField])) {
+                    unset($fieldNames[$hiddenField]);
+                }
+            }
+        }
 
         // Compare values between records and make them look nice
         foreach ($fieldNames as $fieldName => $fieldInfo) {

--- a/code/VersionHistoryExtension.php
+++ b/code/VersionHistoryExtension.php
@@ -78,8 +78,19 @@ class VersionHistoryExtension extends DataExtension
             if ($versions->count() === 0) {
                 return false;
             }
-            $toRecord = $versions->first();
-            $fromRecord = ($versions->count() === 1) ? null : $versions->last();
+            $toRecord = Versioned::get_version(
+                $this->owner->class,
+                $this->owner->ID,
+                $versions->first()->Version
+            );
+
+            $fromRecord = ($versions->count() === 1)
+                ? null
+                : Versioned::get_version(
+                    $this->owner->class,
+                    $this->owner->ID,
+                    $versions->last()->Version
+                );
         }
 
         if (!$toRecord) {
@@ -121,7 +132,7 @@ class VersionHistoryExtension extends DataExtension
 
         // Compare values between records and make them look nice
         foreach ($fieldNames as $fieldName => $fieldInfo) {
-            $compareValue = ($fromRecord && $toRecord->$fieldInfo['FieldName'] !== $fromRecord->$fieldInfo['FieldName'])
+            $compareValue = ($fromRecord && $toRecord->{$fieldInfo['FieldName']} !== $fromRecord->{$fieldInfo['FieldName']})
                 ? Diff::compareHTML($this->getVersionFieldValue($fromRecord, $fieldInfo), $this->getVersionFieldValue($toRecord, $fieldInfo))
                 : $this->getVersionFieldValue($toRecord, $fieldInfo);
             $field = ReadonlyField::create("VersionHistory$fieldName", $this->owner->fieldLabel($fieldName), $compareValue);


### PR DESCRIPTION
In some context, it might be advisable to hide some fields from the History tab. e.g.: Hiding the `Password` or `Salt` field if you track the history of the `Member` DataObject.

This pull request implements a new `version_history_hidden_fields` configuration attribute that can be added to DataObjects that implements `VersionHistoryExtension`. It also adds a blurb about this new feature to the README.