### PR TITLE
:bug: Use relation name instead of class name

### DIFF
--- a/code/VersionHistoryExtension.php
+++ b/code/VersionHistoryExtension.php
@@ -95,10 +95,10 @@ class VersionHistoryExtension extends DataExtension
                 'Type' => 'Field',
             );
         }
-        foreach ($this->owner->hasOne() as $has1) {
-            $fieldNames[$has1] = array(
-                'FieldName' => $has1.'ID',
-                'Name' => $has1,
+        foreach ($this->owner->hasOne() as $relation => $class) {
+            $fieldNames[$relation] = array(
+                'FieldName' => $relation.'ID',
+                'Name' => $relation,
                 'Type' => 'HasOne',
             );
         }


### PR DESCRIPTION
This data object would work without issues:

```
class Model extends DataObject {
    private static $db = [
        'Field1' => 'Text',
        'Field2' => 'Text'
    ];

    private static $has_one = [
        'Member' => 'Member'
    ];

}
```

However if I had multiple has ones that linked to the same class:

```
class Model extends DataObject {
    private static $db = [
        'Field1' => 'Text',
        'Field2' => 'Text'
    ];

    private static $has_one = [
        'CreatedBy' => 'Member',
        'ModifiedBy' => 'Member'
    ];

}
```

The existing code wouldn't work as the code was previously using the class name to figure out what the has one ID field was.

In this case, the ID fields would be `CreatedByID` and `ModifiedByID` The old code would instead look for `MemberID`

Modified the code to use the relation name instead.